### PR TITLE
Readme(!) improvments(?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,18 @@ you are like me and want to _quickly_ start working on - and deploy! - a minimal
 to initiate a new Django project using this starter kit template, copy-paste & run all of the code below:
 
 ```bash
-echo -n "what's your project name (keep it short, lowercase, etc.)? "
+echo -n "what's your project name (short, lowercase-only, no spaces or hyphens, etc.)? "
 read PROJECTNAME
+mkdir $PROJECTNAME
+cd $PROJECTNAME
 python3 -m venv venv
 source venv/bin/activate
 pip install Django==4.2.5
 django-admin startproject --template=https://github.com/gregsadetsky/minimalish-django-starter/archive/main.zip -n ".env.example" -n "render.yaml" $PROJECTNAME .
 pip install -r requirements.txt
-mv starter $PROJECTNAME
 git init
+mv starter $PROJECTNAME
+mv README.starter.md README.md
 ```
 
 then:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cd $PROJECTNAME
 python3 -m venv venv
 source venv/bin/activate
 pip install Django==4.2.5
-django-admin startproject --template=https://github.com/gregsadetsky/minimalish-django-starter/archive/main.zip -n ".env.example" -n "render.yaml" $PROJECTNAME .
+django-admin startproject --template=https://github.com/gregsadetsky/minimalish-django-starter/archive/main.zip -n ".env.example" -n "render.yaml" -n "README.starter.md" $PROJECTNAME .
 pip install -r requirements.txt
 git init
 mv starter $PROJECTNAME

--- a/README.starter.md
+++ b/README.starter.md
@@ -1,0 +1,55 @@
+# Django project {{ project_name}}
+
+Hi! This is the Django source for {{ project_name}}.
+
+## TODO
+
+If you followed the [minimalish django starter](https://github.com/gregsadetsky/minimalish-django-starter) instructions, you still have a couple of steps to go to make a thing that lives on the internet.
+
+next:
+
+- create a new postgres database locally ([look here for more](#you-need-a-postgresql-database))
+- duplicate `.env.example` to `.env` and fill it out
+- run `python manage.py migrate`
+- start the server with `python manage.py runserver`
+- do good work
+
+finally:
+
+- create a new repo (on github -- [go here](https://github.com/new))
+- git add/commit/push all of your code to this new repo
+- go to [render.com](https://render.com/), go to "[Blueprints](https://dashboard.render.com/blueprints)" and click the "New Blueprint Instance" button. assuming that your github account is connected to your render account, connect your new repo with the new blueprint
+  - set the `ALLOWED_HOSTS` value to the domain name you want to use and/or the `.onrender.com` sub-domain (see below). comma separate domains if you have multiple.
+  - it can be confusing to do the previous step because you won't know which .onrender.com domain you'll be given when setting up the blueprint... uh... I guess you can write some domain in ALLOWED_HOSTS like example.com, do the render blueprint deployment, then see which domain you actually got, and then edit the ALLOWED_HOSTS value to the right .onrender.com domain... sorry, this is not perfect! TODO make it better.
+- ok phew, you should be live!!!
+- delete this whole TODO section in this readme and anything else you want to delete; you could keep the little [powered by minimalish django starter](https://github.com/gregsadetsky/minimalish-django-starter) note at the bottom? but don't fret.
+
+# Development basics
+
+## You need a PostgreSQL database
+
+For the project to work in development mode, you'll need to have PostgreSQL running, and PostgreSQL will need to have a database named `{{ project_name}}` inside it. If you're on mac, I suggest [Postgres.app](https://postgresapp.com/) to run postgres locally and [Postico](https://eggerapps.at/postico2/) to view & change stuff in the database.
+
+## Getting started the first time
+
+To get started, navigate to the directory where this code lives. If you're downloading this code fresh, you'll need to run these commands:
+
+```
+python3 -m venv venv
+pip install -r requirements.txt
+```
+
+## Getting started every time
+
+If you've done that before, or if you just did the [minimalish-django-starter setup](https://github.com/gregsadetsky/minimalish-django-starter), you can skip those two lines and just run
+
+```
+source venv/bin/activate
+python manage.py runserver
+```
+
+If you get hollered at to run some other command like `python manage.py migrate` hit Ctrl-C to stop the server, do that and then run `python manage.py runserver` again, no worries.
+
+-----
+
+[powered by minimalish django starter](https://github.com/gregsadetsky/minimalish-django-starter) 


### PR DESCRIPTION
I footgunned myself trying to create a project because I was thinking "minimalish-django-starter" and so I was like "robs-django-starter sounds like a good project name" but no, hyphens are no good, so I'm making that text more assertive

It's easier to undo "creating something in an unnecessarily deep subdirectory" than "oh no I just started a django project in my repository home" so I added mkdir and cd instructions to the script.

Overwrite the readme containing the script with a project-specific readme as the last step in the script in the readme. The new README is a little duplicative of this one but I think that's reasonable. The project-specific readme also tries to think about someone downloading the specific project, rather than starting from the template.